### PR TITLE
chore: add Claude Code entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -411,4 +411,10 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# Claude Code
+# Local settings and session data
+.claude/
+.claude-code/
+*.claude-session
+
 # End of https://www.toptal.com/developers/gitignore/api/react,reactnative,macos,windows,linux


### PR DESCRIPTION
## Summary

Updates `.gitignore` to exclude Claude Code related files and directories from version control.

## Changes

Added the following entries to `.gitignore`:
- `.claude/` - Local settings and improvement plans directory
- `.claude-code/` - Alternative Claude Code directory name
- `*.claude-session` - Claude Code session files

## Why

The `.claude/` directory is used to store:
- Local Claude Code settings (`settings.local.json`)
- Project improvement plans and notes
- Session-specific data

These files are local to each developer and should not be committed to the repository.

## What's in .claude/ (local only)

Currently contains:
- `improvement-plans.md` - Back-of-house improvement recommendations (10 items)
- `settings.local.json` - Local Claude Code configuration

## Test Plan

- [x] Verify `.gitignore` change doesn't affect existing tracked files
- [x] Verify `.claude/` directory is now ignored by git
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)