### PR TITLE
fix: remove NODE_ENV=development from Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,8 +25,5 @@
       "Write(./package.json)",
       "Edit(./package.json)"
     ]
-  },
-  "env": {
-    "NODE_ENV": "development"
   }
 }


### PR DESCRIPTION
## Summary

- Removes `NODE_ENV=development` from `.claude/settings.json` env config
- This override was injected into all commands run by Claude Code, causing `next build` to fail with a `useContext` null error during static prerendering
- The setting was unnecessary — `next dev` already sets `NODE_ENV=development` on its own

## Test plan

- [x] `npm run build` completes successfully without the override
- [x] Verified `NODE_ENV` is no longer set in the Claude Code environment after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)