### PR TITLE
chore(deps): remove 5 unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,11 @@
       "name": "ghostbook",
       "version": "0.2.0",
       "dependencies": {
-        "follow-redirects": "^1.16.0",
         "next": "^16.2.4",
-        "node-forge": "^1.3.3",
-        "nth-check": "^3.0.1",
         "react": "^19.2.5",
-        "react-dom": "^19.2.5",
-        "web-vitals": "^5.2.0"
+        "react-dom": "^19.2.5"
       },
       "devDependencies": {
-        "@eslint/eslintrc": "^3.3.5",
         "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -3012,19 +3007,6 @@
         "require-from-string": "^2.0.2"
       }
     },
-    "node_modules/boolbase": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
-      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -4307,26 +4289,6 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -5885,37 +5847,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nth-check": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
-      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -7775,12 +7712,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/web-vitals": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
-      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
-      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,9 @@
   "private": true,
   "homepage": ".",
   "dependencies": {
-    "follow-redirects": "^1.16.0",
     "next": "^16.2.4",
-    "node-forge": "^1.3.3",
-    "nth-check": "^3.0.1",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5",
-    "web-vitals": "^5.2.0"
+    "react-dom": "^19.2.5"
   },
   "scripts": {
     "build": "next build",
@@ -33,7 +29,6 @@
     "postcss": "^8.5.10"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.3.5",
     "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
## Summary

Audit of dependencies found 5 that are not imported anywhere in the codebase:

- **`follow-redirects`** — orphaned security override from CRA era, no transitive dependents
- **`node-forge`** — orphaned security override from CRA era, no transitive dependents
- **`nth-check`** — orphaned security override from CRA era, no transitive dependents
- **`web-vitals`** — CRA holdover, unused since Next.js migration
- **`@eslint/eslintrc`** — not imported in `eslint.config.mjs`; pulled in transitively by eslint

Production dependencies are now just `next`, `react`, and `react-dom`.

Closes #81

## Test plan

- [x] `npm run type-check` — passes
- [x] `npm test` — all 240 tests pass
- [x] `npm run lint` — clean
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)