### PR TITLE
feat: add 3 new ghosts and rename Fingerprints to Ultraviolet

### DIFF
--- a/e2e/interactions.spec.mjs
+++ b/e2e/interactions.spec.mjs
@@ -45,9 +45,7 @@ test.describe('user interactions after deployment', () => {
 
   test.describe('ghost filtering', () => {
     test('selecting evidence shows matching ghosts', async ({ page }) => {
-      await page
-        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
-        .click();
+      await page.locator('.evidenceButton', { hasText: 'Ultraviolet' }).click();
 
       // Should show ghost cards now
       const ghosts = page.locator('.ghost');
@@ -60,9 +58,7 @@ test.describe('user interactions after deployment', () => {
     test('selecting multiple evidence narrows the results', async ({
       page,
     }) => {
-      await page
-        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
-        .click();
+      await page.locator('.evidenceButton', { hasText: 'Ultraviolet' }).click();
 
       const firstCount = await page.locator('.ghost').count();
 
@@ -76,9 +72,7 @@ test.describe('user interactions after deployment', () => {
       page,
     }) => {
       // Banshee: Ultraviolet, Ghost orb, D.O.T.S projector
-      await page
-        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
-        .click();
+      await page.locator('.evidenceButton', { hasText: 'Ultraviolet' }).click();
       await page.locator('.evidenceButton', { hasText: 'Ghost orb' }).click();
       await page
         .locator('.evidenceButton', { hasText: 'D.O.T.S projector' })
@@ -92,9 +86,7 @@ test.describe('user interactions after deployment', () => {
       page,
     }) => {
       // Select Ultraviolet first
-      await page
-        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
-        .click();
+      await page.locator('.evidenceButton', { hasText: 'Ultraviolet' }).click();
 
       // Banshee should be visible (has Ultraviolet)
       await expect(
@@ -118,9 +110,7 @@ test.describe('user interactions after deployment', () => {
       page,
     }) => {
       // Select Ultraviolet
-      await page
-        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
-        .click();
+      await page.locator('.evidenceButton', { hasText: 'Ultraviolet' }).click();
 
       // Rule out all other evidence types
       const toRuleOut = [
@@ -147,9 +137,7 @@ test.describe('user interactions after deployment', () => {
   test.describe('reset button', () => {
     test('reset clears all selected evidence', async ({ page }) => {
       // Select a couple of evidence types
-      await page
-        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
-        .click();
+      await page.locator('.evidenceButton', { hasText: 'Ultraviolet' }).click();
       await page.locator('.evidenceButton', { hasText: 'Ghost orb' }).click();
 
       // Verify some ghosts are shown
@@ -167,9 +155,7 @@ test.describe('user interactions after deployment', () => {
     });
 
     test('reset restores the initial "no ghosts" message', async ({ page }) => {
-      await page
-        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
-        .click();
+      await page.locator('.evidenceButton', { hasText: 'Ultraviolet' }).click();
 
       await page.locator('.resetButton').click();
 
@@ -184,9 +170,7 @@ test.describe('user interactions after deployment', () => {
       page,
     }) => {
       // Select evidence to show some ghosts
-      await page
-        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
-        .click();
+      await page.locator('.evidenceButton', { hasText: 'Ultraviolet' }).click();
 
       // Find the first ghost's details button
       const firstGhost = page.locator('.ghost').first();
@@ -210,9 +194,7 @@ test.describe('user interactions after deployment', () => {
     test('clicking details button again hides the details', async ({
       page,
     }) => {
-      await page
-        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
-        .click();
+      await page.locator('.evidenceButton', { hasText: 'Ultraviolet' }).click();
 
       const firstGhost = page.locator('.ghost').first();
       const detailsBtn = firstGhost.locator('.detailsButton');
@@ -228,9 +210,7 @@ test.describe('user interactions after deployment', () => {
   test.describe('evidence disabling', () => {
     test('impossible evidence buttons become disabled', async ({ page }) => {
       // Narrow down to Banshee: Ultraviolet, Ghost orb, D.O.T.S projector
-      await page
-        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
-        .click();
+      await page.locator('.evidenceButton', { hasText: 'Ultraviolet' }).click();
       await page.locator('.evidenceButton', { hasText: 'Ghost orb' }).click();
       await page
         .locator('.evidenceButton', { hasText: 'D.O.T.S projector' })
@@ -256,9 +236,7 @@ test.describe('user interactions after deployment', () => {
       page,
     }) => {
       // Narrow down to trigger disabling
-      await page
-        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
-        .click();
+      await page.locator('.evidenceButton', { hasText: 'Ultraviolet' }).click();
       await page.locator('.evidenceButton', { hasText: 'Ghost orb' }).click();
       await page
         .locator('.evidenceButton', { hasText: 'D.O.T.S projector' })
@@ -277,9 +255,7 @@ test.describe('user interactions after deployment', () => {
 
     test('disabled buttons do not respond to clicks', async ({ page }) => {
       // Narrow down to trigger disabling
-      await page
-        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
-        .click();
+      await page.locator('.evidenceButton', { hasText: 'Ultraviolet' }).click();
       await page.locator('.evidenceButton', { hasText: 'Ghost orb' }).click();
       await page
         .locator('.evidenceButton', { hasText: 'D.O.T.S projector' })
@@ -316,9 +292,7 @@ test.describe('user interactions after deployment', () => {
     }) => {
       // Select The Mimic's primary evidence
       await page.locator('.evidenceButton', { hasText: 'Spirit box' }).click();
-      await page
-        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
-        .click();
+      await page.locator('.evidenceButton', { hasText: 'Ultraviolet' }).click();
       await page
         .locator('.evidenceButton', {
           hasText: 'Freezing temperatures',

--- a/e2e/interactions.spec.mjs
+++ b/e2e/interactions.spec.mjs
@@ -46,7 +46,7 @@ test.describe('user interactions after deployment', () => {
   test.describe('ghost filtering', () => {
     test('selecting evidence shows matching ghosts', async ({ page }) => {
       await page
-        .locator('.evidenceButton', { hasText: 'Fingerprints' })
+        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
         .click();
 
       // Should show ghost cards now
@@ -61,7 +61,7 @@ test.describe('user interactions after deployment', () => {
       page,
     }) => {
       await page
-        .locator('.evidenceButton', { hasText: 'Fingerprints' })
+        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
         .click();
 
       const firstCount = await page.locator('.ghost').count();
@@ -75,9 +75,9 @@ test.describe('user interactions after deployment', () => {
     test('selecting three evidence for Banshee shows Banshee', async ({
       page,
     }) => {
-      // Banshee: Fingerprints, Ghost orb, D.O.T.S projector
+      // Banshee: Ultraviolet, Ghost orb, D.O.T.S projector
       await page
-        .locator('.evidenceButton', { hasText: 'Fingerprints' })
+        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
         .click();
       await page.locator('.evidenceButton', { hasText: 'Ghost orb' }).click();
       await page
@@ -91,12 +91,12 @@ test.describe('user interactions after deployment', () => {
     test('ruling out evidence eliminates ghosts with that evidence', async ({
       page,
     }) => {
-      // Select Fingerprints first
+      // Select Ultraviolet first
       await page
-        .locator('.evidenceButton', { hasText: 'Fingerprints' })
+        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
         .click();
 
-      // Banshee should be visible (has Fingerprints)
+      // Banshee should be visible (has Ultraviolet)
       await expect(
         page.locator('.ghostName', { hasText: 'Banshee' })
       ).toBeVisible();
@@ -117,9 +117,9 @@ test.describe('user interactions after deployment', () => {
     test('impossible evidence combination shows no ghosts message', async ({
       page,
     }) => {
-      // Select Fingerprints
+      // Select Ultraviolet
       await page
-        .locator('.evidenceButton', { hasText: 'Fingerprints' })
+        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
         .click();
 
       // Rule out all other evidence types
@@ -148,7 +148,7 @@ test.describe('user interactions after deployment', () => {
     test('reset clears all selected evidence', async ({ page }) => {
       // Select a couple of evidence types
       await page
-        .locator('.evidenceButton', { hasText: 'Fingerprints' })
+        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
         .click();
       await page.locator('.evidenceButton', { hasText: 'Ghost orb' }).click();
 
@@ -168,7 +168,7 @@ test.describe('user interactions after deployment', () => {
 
     test('reset restores the initial "no ghosts" message', async ({ page }) => {
       await page
-        .locator('.evidenceButton', { hasText: 'Fingerprints' })
+        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
         .click();
 
       await page.locator('.resetButton').click();
@@ -185,7 +185,7 @@ test.describe('user interactions after deployment', () => {
     }) => {
       // Select evidence to show some ghosts
       await page
-        .locator('.evidenceButton', { hasText: 'Fingerprints' })
+        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
         .click();
 
       // Find the first ghost's details button
@@ -211,7 +211,7 @@ test.describe('user interactions after deployment', () => {
       page,
     }) => {
       await page
-        .locator('.evidenceButton', { hasText: 'Fingerprints' })
+        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
         .click();
 
       const firstGhost = page.locator('.ghost').first();
@@ -227,9 +227,9 @@ test.describe('user interactions after deployment', () => {
 
   test.describe('evidence disabling', () => {
     test('impossible evidence buttons become disabled', async ({ page }) => {
-      // Narrow down to Banshee: Fingerprints, Ghost orb, D.O.T.S projector
+      // Narrow down to Banshee: Ultraviolet, Ghost orb, D.O.T.S projector
       await page
-        .locator('.evidenceButton', { hasText: 'Fingerprints' })
+        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
         .click();
       await page.locator('.evidenceButton', { hasText: 'Ghost orb' }).click();
       await page
@@ -257,7 +257,7 @@ test.describe('user interactions after deployment', () => {
     }) => {
       // Narrow down to trigger disabling
       await page
-        .locator('.evidenceButton', { hasText: 'Fingerprints' })
+        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
         .click();
       await page.locator('.evidenceButton', { hasText: 'Ghost orb' }).click();
       await page
@@ -278,7 +278,7 @@ test.describe('user interactions after deployment', () => {
     test('disabled buttons do not respond to clicks', async ({ page }) => {
       // Narrow down to trigger disabling
       await page
-        .locator('.evidenceButton', { hasText: 'Fingerprints' })
+        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
         .click();
       await page.locator('.evidenceButton', { hasText: 'Ghost orb' }).click();
       await page
@@ -317,7 +317,7 @@ test.describe('user interactions after deployment', () => {
       // Select The Mimic's primary evidence
       await page.locator('.evidenceButton', { hasText: 'Spirit box' }).click();
       await page
-        .locator('.evidenceButton', { hasText: 'Fingerprints' })
+        .locator('.evidenceButton', { hasText: 'Ultraviolet' })
         .click();
       await page
         .locator('.evidenceButton', {

--- a/e2e/render.spec.mjs
+++ b/e2e/render.spec.mjs
@@ -26,7 +26,7 @@ test.describe('page rendering after deployment', () => {
     const evidenceNames = [
       'Ghost orb',
       'Spirit box',
-      'Fingerprints',
+      'Ultraviolet',
       'EMF Level 5',
       'Freezing temperatures',
       'Ghost writing',

--- a/src/__tests__/Ghost.test.tsx
+++ b/src/__tests__/Ghost.test.tsx
@@ -5,13 +5,13 @@ import Ghost from '../components/Ghost';
 
 const bansheeProps = {
   name: 'Banshee',
-  evidence_list: ['Fingerprints', 'Ghost orb', 'D.O.T.S projector'],
+  evidence_list: ['Ultraviolet', 'Ghost orb', 'D.O.T.S projector'],
   fake_evidence_list: [],
 };
 
 const mimicProps = {
   name: 'The Mimic',
-  evidence_list: ['Spirit box', 'Fingerprints', 'Freezing temperatures'],
+  evidence_list: ['Spirit box', 'Ultraviolet', 'Freezing temperatures'],
   fake_evidence_list: ['Ghost orb'],
 };
 
@@ -23,7 +23,7 @@ describe('Ghost component', () => {
 
   it('renders all primary evidence items', () => {
     render(<Ghost {...bansheeProps} />);
-    expect(screen.getByText('Fingerprints')).toBeInTheDocument();
+    expect(screen.getByText('Ultraviolet')).toBeInTheDocument();
     expect(screen.getByText('Ghost orb')).toBeInTheDocument();
     expect(screen.getByText('D.O.T.S projector')).toBeInTheDocument();
   });

--- a/src/__tests__/Ghostbook.test.tsx
+++ b/src/__tests__/Ghostbook.test.tsx
@@ -87,10 +87,10 @@ describe('Ghostbook integration', () => {
       const user = userEvent.setup();
       render(<Ghostbook />);
 
-      await clickEvidence(user, 'Fingerprints');
+      await clickEvidence(user, 'Ultraviolet');
 
       const visible = getVisibleGhostNames();
-      const expected = expectedGhostsForEvidence(['Fingerprints']);
+      const expected = expectedGhostsForEvidence(['Ultraviolet']);
       expect(visible.sort()).toEqual(expected.sort());
       expect(visible.length).toBeGreaterThan(0);
     });
@@ -99,7 +99,7 @@ describe('Ghostbook integration', () => {
       const user = userEvent.setup();
       render(<Ghostbook />);
 
-      await clickEvidence(user, 'Fingerprints');
+      await clickEvidence(user, 'Ultraviolet');
       const afterFirst = getVisibleGhostNames();
 
       await clickEvidence(user, 'Ghost orb');
@@ -107,16 +107,16 @@ describe('Ghostbook integration', () => {
 
       expect(afterSecond.length).toBeLessThan(afterFirst.length);
 
-      const expected = expectedGhostsForEvidence(['Fingerprints', 'Ghost orb']);
+      const expected = expectedGhostsForEvidence(['Ultraviolet', 'Ghost orb']);
       expect(afterSecond.sort()).toEqual(expected.sort());
     });
 
     it('shows exactly one ghost when three unique evidence types are selected', async () => {
-      // Banshee: Fingerprints, Ghost orb, D.O.T.S projector
+      // Banshee: Ultraviolet, Ghost orb, D.O.T.S projector
       const user = userEvent.setup();
       render(<Ghostbook />);
 
-      await clickEvidence(user, 'Fingerprints');
+      await clickEvidence(user, 'Ultraviolet');
       await clickEvidence(user, 'Ghost orb');
       await clickEvidence(user, 'D.O.T.S projector');
 
@@ -149,8 +149,8 @@ describe('Ghostbook integration', () => {
       const user = userEvent.setup();
       render(<Ghostbook />);
 
-      // Select Fingerprints to show some ghosts
-      await clickEvidence(user, 'Fingerprints');
+      // Select Ultraviolet to show some ghosts
+      await clickEvidence(user, 'Ultraviolet');
       const beforeRuleOut = getVisibleGhostNames();
 
       // Rule out Ghost orb (click twice: select then rule out)
@@ -182,7 +182,7 @@ describe('Ghostbook integration', () => {
       render(<Ghostbook />);
 
       // Select some evidence
-      await clickEvidence(user, 'Fingerprints');
+      await clickEvidence(user, 'Ultraviolet');
       await clickEvidence(user, 'Ghost orb');
 
       // Verify ghosts are shown (not the initial "no match" message)
@@ -201,7 +201,7 @@ describe('Ghostbook integration', () => {
       const user = userEvent.setup();
       render(<Ghostbook />);
 
-      await clickEvidence(user, 'Fingerprints');
+      await clickEvidence(user, 'Ultraviolet');
       await clickEvidence(user, 'Ghost orb');
 
       await user.click(screen.getByText('Reset'));
@@ -219,8 +219,8 @@ describe('Ghostbook integration', () => {
       render(<Ghostbook />);
 
       // Select all three Banshee evidence types:
-      // Fingerprints, Ghost orb, D.O.T.S projector
-      await clickEvidence(user, 'Fingerprints');
+      // Ultraviolet, Ghost orb, D.O.T.S projector
+      await clickEvidence(user, 'Ultraviolet');
       await clickEvidence(user, 'Ghost orb');
       await clickEvidence(user, 'D.O.T.S projector');
 
@@ -245,7 +245,7 @@ describe('Ghostbook integration', () => {
       render(<Ghostbook />);
 
       // Narrow down to Banshee
-      await clickEvidence(user, 'Fingerprints');
+      await clickEvidence(user, 'Ultraviolet');
       await clickEvidence(user, 'Ghost orb');
       await clickEvidence(user, 'D.O.T.S projector');
 
@@ -265,7 +265,7 @@ describe('Ghostbook integration', () => {
       const user = userEvent.setup();
       render(<Ghostbook />);
 
-      // The Mimic has primary: Spirit box, Fingerprints, Freezing temps
+      // The Mimic has primary: Spirit box, Ultraviolet, Freezing temps
       // and fake: Ghost orb
       // Selecting Ghost orb should still show The Mimic
       await clickEvidence(user, 'Ghost orb');
@@ -277,8 +277,8 @@ describe('Ghostbook integration', () => {
       const user = userEvent.setup();
       render(<Ghostbook />);
 
-      // Select Fingerprints, then rule out every other evidence.
-      await clickEvidence(user, 'Fingerprints');
+      // Select Ultraviolet, then rule out every other evidence.
+      await clickEvidence(user, 'Ultraviolet');
 
       // Rule out each remaining evidence (click twice: select then rule out)
       const toRuleOut = [
@@ -295,7 +295,7 @@ describe('Ghostbook integration', () => {
         await clickEvidence(user, name);
       }
 
-      // No ghost can have only Fingerprints and nothing else
+      // No ghost can have only Ultraviolet and nothing else
       expect(
         screen.getByText(/no ghosts match the selected evidence/i)
       ).toBeInTheDocument();

--- a/src/__tests__/ObservationList.test.tsx
+++ b/src/__tests__/ObservationList.test.tsx
@@ -93,7 +93,7 @@ describe('ObservationList component', () => {
     const observed = makeObservedEvidence({
       'Ghost orb': evidenceState.SELECTED,
       'Spirit box': evidenceState.RULED_OUT,
-      Fingerprints: evidenceState.DISABLED,
+      Ultraviolet: evidenceState.DISABLED,
     });
 
     render(
@@ -106,7 +106,7 @@ describe('ObservationList component', () => {
 
     expect(screen.getByText('Ghost orb')).toHaveClass(evidenceState.SELECTED);
     expect(screen.getByText('Spirit box')).toHaveClass(evidenceState.RULED_OUT);
-    expect(screen.getByText('Fingerprints')).toHaveClass(
+    expect(screen.getByText('Ultraviolet')).toHaveClass(
       evidenceState.DISABLED
     );
     expect(screen.getByText('EMF Level 5')).toHaveClass(

--- a/src/__tests__/ObservationList.test.tsx
+++ b/src/__tests__/ObservationList.test.tsx
@@ -106,9 +106,7 @@ describe('ObservationList component', () => {
 
     expect(screen.getByText('Ghost orb')).toHaveClass(evidenceState.SELECTED);
     expect(screen.getByText('Spirit box')).toHaveClass(evidenceState.RULED_OUT);
-    expect(screen.getByText('Ultraviolet')).toHaveClass(
-      evidenceState.DISABLED
-    );
+    expect(screen.getByText('Ultraviolet')).toHaveClass(evidenceState.DISABLED);
     expect(screen.getByText('EMF Level 5')).toHaveClass(
       evidenceState.NOT_SELECTED
     );

--- a/src/__tests__/evidence.test.ts
+++ b/src/__tests__/evidence.test.ts
@@ -11,7 +11,7 @@ describe('evidence constants', () => {
     const expectedNames = [
       'Ghost orb',
       'Spirit box',
-      'Fingerprints',
+      'Ultraviolet',
       'EMF Level 5',
       'Freezing temperatures',
       'Ghost writing',

--- a/src/lib/evidence.ts
+++ b/src/lib/evidence.ts
@@ -1,7 +1,7 @@
 const evidence = {
   GHOST_ORB: 'Ghost orb',
   SPIRIT_BOX: 'Spirit box',
-  FINGERPRINTS: 'Fingerprints',
+  ULTRAVIOLET: 'Ultraviolet',
   EMF_5: 'EMF Level 5',
   FREEZING: 'Freezing temperatures',
   GHOST_WRITING: 'Ghost writing',

--- a/src/lib/ghost_data_map.json
+++ b/src/lib/ghost_data_map.json
@@ -1,14 +1,14 @@
 [
   {
     "Banshee": {
-      "evidence_list": ["Fingerprints", "Ghost orb", "D.O.T.S projector"],
+      "evidence_list": ["Ultraviolet", "Ghost orb", "D.O.T.S projector"],
       "fake_evidence_list": [],
       "strength": "Will target only one player at a time",
       "weakness": "Makes unique paranormal sounds on a parabolic microphone"
     },
     "Demon": {
       "evidence_list": [
-        "Fingerprints",
+        "Ultraviolet",
         "Ghost writing",
         "Freezing temperatures"
       ],
@@ -16,26 +16,38 @@
       "strength": "Can initiate hunts more often",
       "weakness": "Increased effective crucifix range"
     },
+    "Dayan": {
+      "evidence_list": ["EMF Level 5", "Ghost orb", "Spirit box"],
+      "fake_evidence_list": [],
+      "strength": "Gains speed and strength from nearby player movement",
+      "weakness": "Loses strength if people close to her stand still"
+    },
     "Deogen": {
       "evidence_list": ["Spirit box", "Ghost writing", "D.O.T.S projector"],
       "fake_evidence_list": [],
       "strength": "Always knows where players are during a hunt",
       "weakness": "Significantly slows down when in line-of-sight and near the player"
     },
+    "Gallu": {
+      "evidence_list": ["EMF Level 5", "Ultraviolet", "Spirit box"],
+      "fake_evidence_list": [],
+      "strength": "Using protective equipment pushes the ghost to become enraged, weakening equipment effects",
+      "weakness": "Being enraged exhausts the Gallu, making protective equipment more effective"
+    },
     "Goryo": {
-      "evidence_list": ["EMF Level 5", "Fingerprints", "D.O.T.S projector"],
+      "evidence_list": ["EMF Level 5", "Ultraviolet", "D.O.T.S projector"],
       "fake_evidence_list": [],
       "strength": "Can only be seen interacting with D.O.T.S. through a camera when nobody is nearby",
       "weakness": "Tends to wander away less from its ghost room"
     },
     "Hantu": {
-      "evidence_list": ["Fingerprints", "Ghost orb", "Freezing temperatures"],
+      "evidence_list": ["Ultraviolet", "Ghost orb", "Freezing temperatures"],
       "fake_evidence_list": [],
       "strength": "Lower temperatures allow the Hantu to move faster",
       "weakness": "Warmer areas slow the Hantu's movement"
     },
     "Jinn": {
-      "evidence_list": ["EMF Level 5", "Fingerprints", "Freezing temperatures"],
+      "evidence_list": ["EMF Level 5", "Ultraviolet", "Freezing temperatures"],
       "fake_evidence_list": [],
       "strength": "Travels at faster speeds if its victim is far away",
       "weakness": "Cannot use its ability if the site's fuse box is off"
@@ -53,16 +65,22 @@
       "weakness": "Strongly affected by smudge sticks"
     },
     "Myling": {
-      "evidence_list": ["EMF Level 5", "Fingerprints", "Ghost writing"],
+      "evidence_list": ["EMF Level 5", "Ultraviolet", "Ghost writing"],
       "fake_evidence_list": [],
       "strength": "Has quieter footsteps during a hunt",
       "weakness": "Produces paranormal sounds more frequently"
     },
     "Obake": {
-      "evidence_list": ["EMF Level 5", "Ghost orb", "Fingerprints"],
+      "evidence_list": ["EMF Level 5", "Ghost orb", "Ultraviolet"],
       "fake_evidence_list": [],
       "strength": "May leave fingerprints that disappear quicker",
       "weakness": "Has a small chance of leaving six-fingered handprints"
+    },
+    "Obambo": {
+      "evidence_list": ["Ultraviolet", "Ghost writing", "D.O.T.S projector"],
+      "fake_evidence_list": [],
+      "strength": "While aggressive, the Obambo is quicker to start hunting",
+      "weakness": "While calm, the Obambo is slower to start hunting and easier to track"
     },
     "Oni": {
       "evidence_list": [
@@ -81,13 +99,13 @@
       "weakness": "The presence of flames reduces the Onryo's ability to attack"
     },
     "Phantom": {
-      "evidence_list": ["Spirit box", "Fingerprints", "D.O.T.S projector"],
+      "evidence_list": ["Spirit box", "Ultraviolet", "D.O.T.S projector"],
       "fake_evidence_list": [],
       "strength": "Looking at a Phantom will lower the player's sanity considerably",
       "weakness": "Taking a photo of the Phantom will cause it to briefly disappear"
     },
     "Poltergeist": {
-      "evidence_list": ["Spirit box", "Fingerprints", "Ghost writing"],
+      "evidence_list": ["Spirit box", "Ultraviolet", "Ghost writing"],
       "fake_evidence_list": [],
       "strength": "Capable of throwing multiple objects at once",
       "weakness": "Becomes powerless with no throwables nearby"
@@ -127,7 +145,7 @@
       "weakness": "Thaye will weaken over time, making them weaker, slower and less aggressive"
     },
     "The Mimic": {
-      "evidence_list": ["Spirit box", "Fingerprints", "Freezing temperatures"],
+      "evidence_list": ["Spirit box", "Ultraviolet", "Freezing temperatures"],
       "fake_evidence_list": ["Ghost orb"],
       "strength": "Can mimic the abilities and traits of other ghosts",
       "weakness": "Will present Ghost Orbs as a secondary evidence"


### PR DESCRIPTION
## Summary
- Add 3 new ghosts from the Winter's Jest update (v0.15.1.0, Dec 2025): **Dayan**, **Gallu**, and **Obambo** with their evidence, strengths, and weaknesses
- Rename the **Fingerprints** evidence type to **Ultraviolet** across all source and test files to match current in-game terminology

## Test plan
- [x] All 264 unit tests pass
- [ ] Verify new ghosts appear correctly in the UI when their evidence is selected
- [ ] Verify "Ultraviolet" label renders correctly on the evidence button
- [ ] E2e tests pass against deployed build

🤖 Generated with [Claude Code](https://claude.com/claude-code)