### PR TITLE
feat: add Aswang and Kormos ghost types

### DIFF
--- a/src/lib/ghost_data_map.json
+++ b/src/lib/ghost_data_map.json
@@ -1,5 +1,15 @@
 [
   {
+    "Aswang": {
+      "evidence_list": [
+        "D.O.T.S projector",
+        "Freezing temperatures",
+        "Ghost writing"
+      ],
+      "fake_evidence_list": [],
+      "strength": "When they spot their target, Aswangs become faster in pursuit",
+      "weakness": "Aswangs prefer chasing over searching"
+    },
     "Banshee": {
       "evidence_list": ["Ultraviolet", "Ghost orb", "D.O.T.S projector"],
       "fake_evidence_list": [],
@@ -39,6 +49,12 @@
       "fake_evidence_list": [],
       "strength": "Can only be seen interacting with D.O.T.S. through a camera when nobody is nearby",
       "weakness": "Tends to wander away less from its ghost room"
+    },
+    "Kormos": {
+      "evidence_list": ["Ghost orb", "Spirit box", "Ultraviolet"],
+      "fake_evidence_list": [],
+      "strength": "Kormos have incredibly strong hearing",
+      "weakness": "Kormos are nearly blind"
     },
     "Hantu": {
       "evidence_list": ["Ultraviolet", "Ghost orb", "Freezing temperatures"],


### PR DESCRIPTION
## Summary
- Add 2 new ghost types from Phasmophobia v0.17.1.0 update
- **Aswang**: D.O.T.S Projector, Freezing Temperatures, Ghost Writing
- **Kormos**: Ghost Orb, Spirit Box, Ultraviolet
- Brings total ghost count from 27 to 29

## Test plan
- [ ] Verify build succeeds
- [ ] Confirm both ghosts appear in the ghost list
- [ ] Verify evidence filtering works correctly for both new ghosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)