### PR TITLE
feat: add Deildegast ghost

### DIFF
--- a/src/lib/ghost_data_map.json
+++ b/src/lib/ghost_data_map.json
@@ -32,6 +32,12 @@
       "strength": "Gains speed and strength from nearby player movement",
       "weakness": "Loses strength if people close to her stand still"
     },
+    "Deildegast": {
+      "evidence_list": ["EMF Level 5", "Ghost writing", "D.O.T.S projector"],
+      "fake_evidence_list": [],
+      "strength": "Moves faster than any other ghost, with the highest base speed",
+      "weakness": "Picking up and moving nearby objects steadily slows it down"
+    },
     "Deogen": {
       "evidence_list": ["Spirit box", "Ghost writing", "D.O.T.S projector"],
       "fake_evidence_list": [],


### PR DESCRIPTION
## Summary

Adds the **Deildegast** — the newest ghost type in the latest Phasmophobia release (the third ghost added in 2026) — to the evidence/identification data.

| Field | Value |
|-------|-------|
| **Evidence** | EMF Level 5, Ghost Writing, D.O.T.S Projector |
| **Strength** | Highest base speed of any ghost (3.0 m/s), aggressive hunts |
| **Weakness** | Slows down as nearby objects are picked up and moved |

## Implementation

- Single entry added to `src/lib/ghost_data_map.json` (in the D-cluster, between Dayan and Deogen).
- The app is fully data-driven off that file — rendering (`Ghost.tsx`), scoring/filtering (`Ghostbook.tsx`), and candidate list (`CandidateList.tsx`) all read from it — so **no component or asset changes** are needed.
- Uses the canonical evidence strings from `src/lib/evidence.ts`. The EMF + Ghost Writing + D.O.T.S combo is unique and not shared with any existing ghost.

## Verification

- `npm run type-check` ✓
- Prettier ✓
- `npm test` → **288 unit tests pass** — the per-ghost suite in `ghostData.test.ts` auto-validates the new entry (exactly 3 valid evidence names, non-empty strength/weakness, no evidence/fake overlap)
- `npm run build` ✓

## Sources

Evidence and behaviour cross-verified across:
- [The Escapist — Deildegast ghost guide](https://www.escapistmagazine.com/news-phasmophobias-deildegast-ghost-guide/)
- [Game Rant — All Deildegast Ghost Evidence](https://gamerant.com/phasmophobia-deildegast-ghost-guide-evidence/)
- [VPEsports — Deildegast guide](https://vpesports.com/guides/deildegast-in-phasmophobia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)