### PR TITLE
feat: CRT terminal theme with high-legibility mode

### DIFF
--- a/e2e/interactions.spec.mjs
+++ b/e2e/interactions.spec.mjs
@@ -310,4 +310,57 @@ test.describe('user interactions after deployment', () => {
       await expect(fakeEvidence).toContainText('Ghost orb');
     });
   });
+
+  test.describe('high-legibility mode', () => {
+    test('toggling on sets data-legible and persists across reload', async ({
+      page,
+    }) => {
+      const html = page.locator('html');
+      const toggle = page.locator('.legibleToggle');
+
+      await expect(html).toHaveAttribute('data-legible', 'off');
+
+      await toggle.click();
+      await expect(html).toHaveAttribute('data-legible', 'on');
+      await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+      // The choice is restored from localStorage after a reload.
+      await page.reload();
+      await expect(page.locator('html')).toHaveAttribute('data-legible', 'on');
+      await expect(page.locator('.legibleToggle')).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      );
+    });
+
+    test('toggling swaps the font between Silkscreen and Source Code Pro', async ({
+      page,
+    }) => {
+      const body = page.locator('body');
+      const fontOf = () =>
+        body.evaluate((el) => getComputedStyle(el).fontFamily.toLowerCase());
+
+      expect(await fontOf()).toContain('silkscreen');
+
+      await page.locator('.legibleToggle').click();
+      expect(await fontOf()).toContain('source'); // Source Code Pro
+
+      await page.locator('.legibleToggle').click();
+      expect(await fontOf()).toContain('silkscreen');
+    });
+
+    test('high-legibility mode removes the title glow', async ({ page }) => {
+      const heading = page.locator('header h1');
+      const shadowOf = () =>
+        heading.evaluate((el) => getComputedStyle(el).textShadow);
+
+      // Normal mode: the title carries a glow.
+      expect(await shadowOf()).not.toBe('none');
+
+      await page.locator('.legibleToggle').click();
+
+      // High-legibility mode strips every text-shadow.
+      expect(await shadowOf()).toBe('none');
+    });
+  });
 });

--- a/e2e/render.spec.mjs
+++ b/e2e/render.spec.mjs
@@ -69,12 +69,24 @@ test.describe('page rendering after deployment', () => {
     );
   });
 
-  test('page uses the Cutive Mono font family', async ({ page }) => {
+  test('page uses the Silkscreen terminal font by default', async ({
+    page,
+  }) => {
     const body = page.locator('body');
     const fontFamily = await body.evaluate(
       (el) => getComputedStyle(el).fontFamily
     );
-    expect(fontFamily.toLowerCase()).toContain('cutive');
+    expect(fontFamily.toLowerCase()).toContain('silkscreen');
+  });
+
+  test('high-legibility mode toggle renders, off by default', async ({
+    page,
+  }) => {
+    const toggle = page.locator('.legibleToggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toContainText(/high-legibility mode/i);
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.locator('html')).toHaveAttribute('data-legible', 'off');
   });
 
   test('no console errors on page load', async ({ page }) => {

--- a/src/__tests__/DisplaySettings.test.tsx
+++ b/src/__tests__/DisplaySettings.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DisplaySettings from '../components/DisplaySettings';
+
+const STORAGE_KEY = 'ghostbook:legible';
+
+// jsdom in this project doesn't expose localStorage; provide an in-memory one
+// so the component's persistence path is exercised.
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: (k: string) => (k in store ? store[k] : null),
+  setItem: (k: string, v: string) => {
+    store[k] = v;
+  },
+  removeItem: (k: string) => {
+    delete store[k];
+  },
+  clear: () => {
+    for (const k of Object.keys(store)) delete store[k];
+  },
+};
+
+beforeEach(() => {
+  Object.defineProperty(window, 'localStorage', {
+    value: localStorageMock,
+    configurable: true,
+    writable: true,
+  });
+  localStorageMock.clear();
+  document.documentElement.removeAttribute('data-legible');
+});
+
+describe('DisplaySettings', () => {
+  it('renders the high-legibility toggle, off by default', () => {
+    render(<DisplaySettings />);
+    const toggle = screen.getByRole('button', {
+      name: /high-legibility mode/i,
+    });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    expect(document.documentElement.getAttribute('data-legible')).toBe('off');
+  });
+
+  it('enables legible mode on click and persists it', async () => {
+    const user = userEvent.setup();
+    render(<DisplaySettings />);
+    const toggle = screen.getByRole('button', {
+      name: /high-legibility mode/i,
+    });
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    expect(document.documentElement.getAttribute('data-legible')).toBe('on');
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('on');
+  });
+
+  it('restores a saved "on" preference on mount', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'on');
+    render(<DisplaySettings />);
+    const toggle = screen.getByRole('button', {
+      name: /high-legibility mode/i,
+    });
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    expect(document.documentElement.getAttribute('data-legible')).toBe('on');
+  });
+
+  it('toggles back off and persists that too', async () => {
+    window.localStorage.setItem(STORAGE_KEY, 'on');
+    const user = userEvent.setup();
+    render(<DisplaySettings />);
+    const toggle = screen.getByRole('button', {
+      name: /high-legibility mode/i,
+    });
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    expect(document.documentElement.getAttribute('data-legible')).toBe('off');
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('off');
+  });
+});

--- a/src/__tests__/Ghostbook.test.tsx
+++ b/src/__tests__/Ghostbook.test.tsx
@@ -80,6 +80,15 @@ describe('Ghostbook integration', () => {
       render(<Ghostbook />);
       expect(screen.getByText('Reset')).toBeInTheDocument();
     });
+
+    it('renders the high-legibility mode toggle', () => {
+      render(<Ghostbook />);
+      const toggle = screen.getByRole('button', {
+        name: /high-legibility mode/i,
+      });
+      expect(toggle).toBeInTheDocument();
+      expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    });
   });
 
   describe('selecting evidence', () => {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,15 +6,16 @@
    ========================================================================= */
 
 :root {
-  --font-terminal: 'VT323', 'Cutive Mono', ui-monospace, monospace;
-  --font-mono: 'Cutive Mono', ui-monospace, monospace;
+  /* Silkscreen for the CRT look; high-legibility mode swaps in Source Code Pro. */
+  --font-terminal: var(--font-silkscreen), var(--font-cutive), monospace;
+  --font-mono: var(--font-cutive), ui-monospace, monospace;
 
   /* Phosphor palette */
   --crt-black: #050805;
   --crt-screen: #0a120a;
   --green: #33ff66;
   --green-bright: #b9ffcf;
-  --green-dim: #1f9a44;
+  --green-dim: #2fb35a;
   --green-faint: rgba(51, 255, 102, 0.35);
   --amber: #ffb638; /* ruled-out / warnings */
   --amber-dim: rgba(255, 182, 56, 0.5);
@@ -43,7 +44,7 @@ body {
   letter-spacing: 0.02em;
   padding: 1em;
   min-height: 100vh;
-  text-shadow: var(--glow-soft);
+  /* Glow lives on headings/accents only — body text stays crisp. */
 }
 
 /* The #root is the lit "screen": bezel, vignette, and clipped overlays. */
@@ -136,6 +137,13 @@ h1 {
   margin: 0.2em 0;
 }
 
+/* The main title is large in the pixel font, so keep its glow tight to
+   avoid a heavy blur. */
+.ghostBook > header h1,
+.ghostBook > header h1::after {
+  text-shadow: 0 0 2px rgba(51, 255, 102, 0.45);
+}
+
 /* Prompt marker + blinking cursor on the main title. */
 .ghostBook > header h1::before {
   content: 'C:\\GHOSTBOOK> ';
@@ -176,6 +184,39 @@ h1 {
 .button {
   cursor: pointer;
   font-size: 1em;
+}
+
+/* ---- Display / accessibility toggle ------------------------------------- */
+
+.displaySettings {
+  display: flex;
+  justify-content: flex-end;
+  margin: -0.4em 0 1.2em;
+}
+
+.legibleToggle {
+  font-family: var(--font-terminal);
+  font-size: 0.8em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--green);
+  background: transparent;
+  border: 1px solid var(--green-faint);
+  padding: 0.35em 0.8em;
+  cursor: pointer;
+}
+.legibleToggle:hover {
+  border-color: var(--green);
+  box-shadow: var(--glow-soft);
+}
+.legibleToggle:focus-visible {
+  outline: 2px solid var(--green);
+  outline-offset: 2px;
+}
+.legibleToggle[aria-pressed='true'] {
+  color: var(--green-bright);
+  border-color: var(--green);
+  background: rgba(51, 255, 102, 0.12);
 }
 
 /* ---- Observations panel ------------------------------------------------- */
@@ -400,6 +441,44 @@ div.ghostDetailsHidden {
   content: '\2715 WEAK '; /* ✕ */
   color: var(--amber-dim);
   color: var(--amber);
+}
+
+/* ---- High-legibility mode ----------------------------------------------
+   Toggled by DisplaySettings (data-legible="on" on <html>) and defaulted from
+   the reader's OS contrast settings. Drops the CRT effects and raises
+   contrast: brighter phosphor, no glow, no scanlines/flicker, no dim text.
+   ------------------------------------------------------------------------ */
+
+:root[data-legible='on'] {
+  /* Source Code Pro reads far cleaner than the pixel font at small sizes. */
+  --font-terminal: var(--font-source-code-pro), var(--font-cutive), monospace;
+  --green: #74ffa4;
+  --green-bright: #e6fff0;
+  --green-dim: #57e88c;
+  --green-faint: rgba(116, 255, 164, 0.55);
+  --amber: #ffc861;
+  --amber-dim: rgba(255, 200, 97, 0.75);
+  --glow: none;
+  --glow-soft: none;
+}
+
+/* Kill every residual text glow for crisp edges. */
+:root[data-legible='on'] * {
+  text-shadow: none !important;
+}
+
+/* Remove the screen overlays and motion. */
+:root[data-legible='on'] #root {
+  animation: none;
+  border-color: var(--green-faint);
+  box-shadow: inset 0 0 0 1px rgba(116, 255, 164, 0.12);
+}
+:root[data-legible='on'] #root::before,
+:root[data-legible='on'] #root::after {
+  display: none;
+}
+:root[data-legible='on'] .evidenceSelected {
+  box-shadow: none;
 }
 
 /* ---- Animations --------------------------------------------------------- */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,38 +1,184 @@
-/* General Styles  */
+/* =========================================================================
+   Ghostbook — CRT terminal theme
+   Green phosphor on black, scanlines, flicker, blinking cursor.
+   All embellishments are pure CSS (pseudo-elements) so the DOM/text the
+   components render — and the tests that query it — stay untouched.
+   ========================================================================= */
+
+:root {
+  --font-terminal: 'VT323', 'Cutive Mono', ui-monospace, monospace;
+  --font-mono: 'Cutive Mono', ui-monospace, monospace;
+
+  /* Phosphor palette */
+  --crt-black: #050805;
+  --crt-screen: #0a120a;
+  --green: #33ff66;
+  --green-bright: #b9ffcf;
+  --green-dim: #1f9a44;
+  --green-faint: rgba(51, 255, 102, 0.35);
+  --amber: #ffb638; /* ruled-out / warnings */
+  --amber-dim: rgba(255, 182, 56, 0.5);
+
+  --glow: 0 0 4px rgba(51, 255, 102, 0.7), 0 0 11px rgba(51, 255, 102, 0.35);
+  --glow-soft: 0 0 3px rgba(51, 255, 102, 0.5);
+}
+
+/* ---- Base screen -------------------------------------------------------- */
+
+html {
+  background: var(--crt-black);
+}
 
 body {
-  background-color: black;
-  color: white;
-  font-family: 'Cutive Mono', monospace, sans-serif;
-  font-size: 100%;
+  background: radial-gradient(
+    ellipse at center,
+    var(--crt-screen) 0%,
+    #060a06 70%,
+    #030503 100%
+  );
+  color: var(--green);
+  font-family: var(--font-terminal);
+  font-size: 140%;
+  line-height: 1.25;
+  letter-spacing: 0.02em;
   padding: 1em;
+  min-height: 100vh;
+  text-shadow: var(--glow-soft);
+}
+
+/* The #root is the lit "screen": bezel, vignette, and clipped overlays. */
+#root {
+  position: relative;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.4em 1.6em 2.4em;
+  border: 2px solid #0c1a0c;
+  border-radius: 14px;
+  background: linear-gradient(rgba(10, 22, 10, 0.35), rgba(4, 8, 4, 0.35));
+  box-shadow:
+    inset 0 0 120px rgba(0, 0, 0, 0.9),
+    inset 0 0 40px rgba(51, 255, 102, 0.06),
+    0 0 3px rgba(51, 255, 102, 0.25);
+  overflow: hidden;
+  animation: flicker 4s infinite steps(60);
+}
+
+/* Scanlines: fine horizontal lines painted over the whole screen. */
+#root::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0) 0,
+    rgba(0, 0, 0, 0) 2px,
+    rgba(0, 0, 0, 0.28) 3px,
+    rgba(0, 0, 0, 0.28) 4px
+  );
+  mix-blend-mode: multiply;
+}
+
+/* Rolling refresh bar sweeping down the screen. */
+#root::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 22%;
+  z-index: 21;
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    rgba(51, 255, 102, 0) 0%,
+    rgba(51, 255, 102, 0.04) 50%,
+    rgba(51, 255, 102, 0) 100%
+  );
+  animation: refresh-roll 7s linear infinite;
+}
+
+/* Keep real content above the overlays. */
+.ghostBook {
+  position: relative;
+  z-index: 1;
 }
 
 section {
-  margin: 2em;
+  margin: 1.6em 0;
+}
+
+/* ---- Headings / boot banner / cursor ------------------------------------ */
+
+.ghostBook > header {
+  border-bottom: 1px solid var(--green-faint);
+  padding-bottom: 0.6em;
+  margin-bottom: 1em;
+}
+
+/* Boot banner above the title. */
+.ghostBook > header::before {
+  content: '[ PARANORMAL DETECTION TERMINAL // v0.2.0 // ONLINE ]';
+  display: block;
+  color: var(--green-dim);
+  font-size: 0.62em;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin-bottom: 0.3em;
 }
 
 h1 {
-  font-size: 1.5em;
+  font-size: 1.6em;
+  font-weight: normal;
+  letter-spacing: 0.04em;
+  color: var(--green-bright);
+  text-shadow: var(--glow);
+  margin: 0.2em 0;
 }
 
-.button {
-  cursor: pointer;
-  font-size: 1.2em;
+/* Prompt marker + blinking cursor on the main title. */
+.ghostBook > header h1::before {
+  content: 'C:\\GHOSTBOOK> ';
+  color: var(--green-dim);
 }
+
+.ghostBook > header h1::after {
+  content: '\2588'; /* full block */
+  margin-left: 0.15em;
+  color: var(--green-bright);
+  animation: blink 1.05s steps(1) infinite;
+}
+
+/* Section headings read like prompt lines. */
+.observations > h1,
+.candidates > h1 {
+  font-size: 1.05em;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.observations > h1::before,
+.candidates > h1::before {
+  content: '> ';
+  color: var(--green-dim);
+}
+
+/* ---- Layout ------------------------------------------------------------- */
 
 .content {
   display: flex;
   flex-direction: row;
   align-content: flex-start;
   align-items: flex-start;
+  gap: 1.5em;
 }
 
-.ghostBook {
-  /* nothing right now */
+.button {
+  cursor: pointer;
+  font-size: 1em;
 }
 
-/* Observation section  */
+/* ---- Observations panel ------------------------------------------------- */
 
 .observations {
   flex-grow: 0;
@@ -40,120 +186,296 @@ h1 {
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
+  border: 1px solid var(--green-faint);
+  padding: 0.4em 1em 1em;
+  background: rgba(51, 255, 102, 0.02);
 }
 
 .observationList {
-  margin: 0.2em;
+  margin: 0.2em 0 0;
   padding-left: 0;
 }
 
 .observationList li {
   list-style-type: none;
-  padding: 0.5em;
-  padding-left: 1em;
-  padding-right: 1em;
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+  position: relative;
+  padding: 0.4em 0.8em;
+  margin: 0.45em 0;
+  border: 1px solid var(--green-dim);
+  color: var(--green);
+  background: transparent;
+  transition:
+    background 0.08s linear,
+    box-shadow 0.08s linear,
+    color 0.08s linear;
 }
 
+.observationList li::before {
+  content: '[ ] ';
+  color: var(--green-dim);
+}
+
+.evidenceButton:hover {
+  box-shadow: var(--glow-soft);
+  border-color: var(--green);
+}
+
+/* --- Evidence states (class names are asserted by tests: keep them) --- */
+
 .evidenceSelected {
-  border: 1px solid white;
-  background-color: white;
-  color: black;
+  border-color: var(--green) !important;
+  background-color: var(--green) !important;
+  color: var(--crt-black) !important;
+  text-shadow: none;
+  box-shadow: var(--glow);
+}
+.evidenceSelected::before {
+  content: '[x] ' !important;
+  color: var(--crt-black) !important;
 }
 
 .evidenceNotSelected {
-  border: 1px solid white;
-  background-color: black;
-  color: white;
+  border-color: var(--green-dim);
+  background-color: transparent;
+  color: var(--green);
 }
 
 .evidenceDisabled {
-  border: 1px solid grey;
-  background-color: black;
-  color: grey;
+  border-color: rgba(51, 255, 102, 0.15);
+  background-color: transparent;
+  color: var(--green-dim);
+  opacity: 0.45;
   text-decoration: line-through;
+  text-shadow: none;
+  cursor: not-allowed;
+}
+.evidenceDisabled::before {
+  content: '[/] ';
+  color: var(--green-dim);
 }
 
 .evidenceRuledOut {
-  border: 1px solid white;
-  background-color: grey;
-  color: black;
+  border-color: var(--amber-dim);
+  background-color: transparent;
+  color: var(--amber);
   text-decoration: line-through;
+  text-shadow: 0 0 4px rgba(255, 182, 56, 0.4);
+}
+.evidenceRuledOut::before {
+  content: '[-] ';
+  color: var(--amber);
 }
 
 .resetButton {
   display: inline-block;
-  padding: 0.3em 1em 0.3em 1em;
-  margin: 0;
-  margin-left: auto;
-  margin-top: 0.4em;
-  border: 1px solid grey;
-  background-color: grey;
-  color: black;
+  align-self: flex-end;
+  padding: 0.3em 1em;
+  margin-top: 0.8em;
+  border: 1px solid var(--amber-dim);
+  background-color: transparent;
+  color: var(--amber);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  text-shadow: 0 0 4px rgba(255, 182, 56, 0.35);
+}
+.resetButton::before {
+  content: '[ ';
+  color: var(--amber-dim);
+}
+.resetButton::after {
+  content: ' ]';
+  color: var(--amber-dim);
+}
+.resetButton:hover {
+  background-color: rgba(255, 182, 56, 0.12);
+  box-shadow: 0 0 8px rgba(255, 182, 56, 0.25);
 }
 
-/* Ghost section  */
+/* ---- Ghost candidates --------------------------------------------------- */
+
+.candidates {
+  flex-grow: 1;
+}
 
 .candidateList {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   align-items: flex-start;
+  gap: 1em;
 }
 
 .ghost {
-  width: 200px;
-  font-size: 1em;
-  margin-bottom: 2em;
+  width: 220px;
+  font-size: 0.92em;
+  margin-bottom: 0.5em;
+  padding: 0.6em 0.8em 0.8em;
+  border: 1px solid var(--green-faint);
+  background: rgba(51, 255, 102, 0.02);
+  box-shadow: inset 0 0 20px rgba(51, 255, 102, 0.03);
+}
+
+.ghost::before {
+  content: '// DOSSIER';
+  display: block;
+  font-size: 0.72em;
+  letter-spacing: 0.16em;
+  color: var(--green-dim);
+  margin-bottom: 0.2em;
 }
 
 .ghostName {
-  font-size: 1.2em;
+  font-size: 1.35em;
+  color: var(--green-bright);
+  text-shadow: var(--glow);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px dashed var(--green-faint);
+  padding-bottom: 0.2em;
+  margin-bottom: 0.3em;
+}
+.ghostName::before {
+  content: '\25B8 '; /* ▸ */
+  color: var(--green-dim);
+}
+
+.evidenceList {
+  list-style: none;
+  padding-left: 0;
+  margin: 0.4em 0;
+}
+.evidenceList li {
+  padding: 0.05em 0;
+}
+.evidenceList li::before {
+  content: '\00B7 '; /* · */
+  color: var(--green-dim);
 }
 
 li.fakeEvidence {
-  color: grey;
+  color: var(--amber);
+  font-style: italic;
+  text-shadow: 0 0 4px rgba(255, 182, 56, 0.3);
+}
+li.fakeEvidence::before {
+  content: '\00B7 ? ';
+  color: var(--amber-dim);
 }
 
 .detailsButton {
-  text-decoration: underline;
   cursor: pointer;
-  background-color: black;
-  color: white;
-  font-family: 'Cutive Mono', monospace, sans-serif;
-  font-size: 100%;
+  background-color: transparent;
+  color: var(--green-dim);
+  font-family: var(--font-terminal);
+  font-size: 0.95em;
+  letter-spacing: 0.05em;
   border: none;
+  padding: 0.2em 0;
+  text-decoration: none;
+}
+.detailsButton:hover {
+  color: var(--green);
+  text-shadow: var(--glow-soft);
 }
 
 div.ghostDetailsShown {
-  font-size: 0.9em;
-  padding-right: 1em;
+  font-size: 0.95em;
+  padding: 0.3em 0.4em;
+  margin-top: 0.3em;
+  border-left: 2px solid var(--green-faint);
 }
-
 div.ghostDetailsHidden {
-  font-size: 0.9em;
-  padding-right: 1em;
   display: none;
 }
 
-/* Media queries */
+/* Label the two detail lines: first = strength, second = weakness. */
+.ghostDetailsShown p {
+  margin: 0.25em 0;
+}
+.ghostDetailsShown p:nth-of-type(1)::before {
+  content: '\26A1 STR  '; /* ⚡ */
+  color: var(--green-dim);
+}
+.ghostDetailsShown p:nth-of-type(2)::before {
+  content: '\2715 WEAK '; /* ✕ */
+  color: var(--amber-dim);
+  color: var(--amber);
+}
+
+/* ---- Animations --------------------------------------------------------- */
+
+@keyframes blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes refresh-roll {
+  0% {
+    transform: translateY(-120%);
+  }
+  100% {
+    transform: translateY(560%);
+  }
+}
+
+@keyframes flicker {
+  0%,
+  96%,
+  100% {
+    opacity: 1;
+  }
+  97% {
+    opacity: 0.94;
+  }
+  98% {
+    opacity: 0.99;
+  }
+  99% {
+    opacity: 0.92;
+  }
+}
+
+/* ---- Motion / responsiveness ------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  #root {
+    animation: none;
+  }
+  #root::after {
+    animation: none;
+    display: none;
+  }
+  .ghostBook > header h1::after {
+    animation: none;
+  }
+}
 
 @media only screen and (max-width: 900px) {
   body {
-    font-size: 1.1em;
+    font-size: 120%;
+  }
+  #root {
+    padding: 1em 1em 1.8em;
+    border-radius: 10px;
   }
   section {
-    margin: 0;
-    margin-bottom: 1em;
+    margin: 0 0 1em;
   }
-
   .content {
     flex-direction: column;
     align-items: stretch;
+    gap: 1em;
   }
-
   .observations {
-    max-width: 60%;
+    max-width: 100%;
+  }
+  .ghost {
+    width: 100%;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,22 +1,31 @@
 import type { Metadata } from 'next';
-import { Cutive_Mono, VT323 } from 'next/font/google';
+import { Silkscreen, Source_Code_Pro, Cutive_Mono } from 'next/font/google';
 import Script from 'next/script';
 import './globals.css';
 
-// VT323 drives the CRT-terminal look; Cutive Mono is a graceful fallback.
-const vt323 = VT323({
+// Silkscreen drives the CRT look; Source Code Pro is used in high-legibility
+// mode; Cutive Mono is a graceful fallback. Each exposes a CSS variable that
+// globals.css wires into --font-terminal.
+const silkscreen = Silkscreen({
   weight: '400',
   subsets: ['latin'],
-  variable: '--font-terminal',
+  variable: '--font-silkscreen',
   display: 'swap',
 });
-
+const sourceCodePro = Source_Code_Pro({
+  weight: '400',
+  subsets: ['latin'],
+  variable: '--font-source-code-pro',
+  display: 'swap',
+});
 const cutiveMono = Cutive_Mono({
   weight: '400',
   subsets: ['latin'],
-  variable: '--font-mono',
-  display: 'optional',
+  variable: '--font-cutive',
+  display: 'swap',
 });
+
+const fontVariables = `${silkscreen.variable} ${sourceCodePro.variable} ${cutiveMono.variable}`;
 
 // Cloudflare Web Analytics - optional, only enabled if token is provided
 const cloudflareToken = process.env.NEXT_PUBLIC_CLOUDFLARE_ANALYTICS_TOKEN;
@@ -36,8 +45,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body className={`${vt323.variable} ${cutiveMono.variable}`}>
+    <html lang="en" className={fontVariables}>
+      <body>
         <div id="root">{children}</div>
         {cloudflareToken && (
           <Script

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,20 @@
 import type { Metadata } from 'next';
-import { Cutive_Mono } from 'next/font/google';
+import { Cutive_Mono, VT323 } from 'next/font/google';
 import Script from 'next/script';
 import './globals.css';
+
+// VT323 drives the CRT-terminal look; Cutive Mono is a graceful fallback.
+const vt323 = VT323({
+  weight: '400',
+  subsets: ['latin'],
+  variable: '--font-terminal',
+  display: 'swap',
+});
 
 const cutiveMono = Cutive_Mono({
   weight: '400',
   subsets: ['latin'],
+  variable: '--font-mono',
   display: 'optional',
 });
 
@@ -28,7 +37,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={cutiveMono.className}>
+      <body className={`${vt323.variable} ${cutiveMono.variable}`}>
         <div id="root">{children}</div>
         {cloudflareToken && (
           <Script

--- a/src/components/DisplaySettings.tsx
+++ b/src/components/DisplaySettings.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'ghostbook:legible';
+
+/** Read the saved preference, falling back to the OS accessibility settings. */
+function getInitialLegible(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    if (saved === 'on') return true;
+    if (saved === 'off') return false;
+  } catch {
+    // localStorage can throw (private mode, disabled) — ignore and use defaults.
+  }
+
+  // No explicit choice yet: honour the system's contrast/color preferences.
+  if (typeof window.matchMedia === 'function') {
+    return (
+      window.matchMedia('(prefers-contrast: more)').matches ||
+      window.matchMedia('(forced-colors: active)').matches
+    );
+  }
+
+  return false;
+}
+
+function applyLegible(on: boolean): void {
+  if (typeof document !== 'undefined') {
+    document.documentElement.setAttribute('data-legible', on ? 'on' : 'off');
+  }
+}
+
+/**
+ * A single "high-legibility mode" toggle. When on, CSS keyed off the
+ * `data-legible` attribute drops the CRT effects (glow, scanlines, flicker)
+ * and raises text contrast. The choice is saved to localStorage and defaults
+ * to the reader's OS accessibility settings.
+ */
+export default function DisplaySettings() {
+  const [legible, setLegible] = useState(false);
+
+  useEffect(() => {
+    const initial = getInitialLegible();
+    setLegible(initial);
+    applyLegible(initial);
+  }, []);
+
+  const toggle = () => {
+    const next = !legible;
+    setLegible(next);
+    applyLegible(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next ? 'on' : 'off');
+    } catch {
+      // Ignore storage failures; the in-session toggle still works.
+    }
+  };
+
+  return (
+    <div className="displaySettings">
+      <button
+        type="button"
+        className="button legibleToggle"
+        onClick={toggle}
+        aria-pressed={legible}
+      >
+        <span aria-hidden="true">{legible ? '[x]' : '[ ]'}</span>{' '}
+        High-legibility mode
+      </button>
+    </div>
+  );
+}

--- a/src/components/Ghostbook.tsx
+++ b/src/components/Ghostbook.tsx
@@ -6,6 +6,7 @@ import evidenceState from '../lib/evidenceState';
 import ghost_data_map from '../lib/ghost_data_map.json';
 import ObservationList from './ObservationList';
 import CandidateList from './CandidateList';
+import DisplaySettings from './DisplaySettings';
 import type { GhostDataMap } from '../lib/types';
 
 const ghosts: GhostDataMap = ghost_data_map[0];
@@ -152,6 +153,7 @@ export default class Ghostbook extends React.Component<
     return (
       <div className="ghostBook">
         <Header />
+        <DisplaySettings />
         <section className="content">
           <ObservationList
             observed_evidence={this.state.observed_evidence}


### PR DESCRIPTION
## Summary

Restyles Ghostbook as a green-phosphor **CRT terminal**, with an accessible **high-legibility mode** so the effect never gets in the way of reading.

## What's included

**CRT theme** (`3295b49`)
- Green-on-black phosphor palette, scanline overlay, rolling refresh bar, subtle flicker, and a bezel/vignette screen frame
- Blinking block cursor + `C:\GHOSTBOOK>` prompt on the title, boot banner, `>` prompts on section headings
- Evidence toggles as terminal checkboxes (`[ ]` / `[x]` / `[-]` / `[/]`); ghost cards restyled as `// DOSSIER` panels with `⚡ STR` / `✕ WEAK` labels
- All embellishments are pure CSS pseudo-elements — no component markup changed

**High-legibility mode + fonts** (`4a29cc3`)
- A single saved **toggle** that flips `data-legible` on `<html>`: drops glow/scanlines/flicker and raises contrast. Persisted to `localStorage`; defaults from the OS `prefers-contrast` / `forced-colors` settings. `localStorage`/`matchMedia` guarded for SSR + jsdom
- Fonts: **Silkscreen** for the CRT look, **Source Code Pro** in high-legibility mode, Cutive Mono fallback (all self-hosted via `next/font`)
- Softened the large title's glow and removed the body-wide glow so text stays crisp

**Tests** (`d408a5c`)
- Unit: `DisplaySettings` (default / toggle / persist / restore)
- Integration: toggle renders in the assembled `Ghostbook`
- E2E: default font is Silkscreen; toggling sets `data-legible` and **persists across reload**; font swaps Silkscreen ↔ Source Code Pro; title glow removed in legible mode. Nested under the existing `page rendering` / `user interactions` describes so CI's grepped e2e jobs run them

## Accessibility

- Honors `prefers-reduced-motion` (disables flicker/roll/cursor blink) and `prefers-contrast` / `forced-colors` (auto-enables legible mode)
- Toggle is a real `<button>` with `aria-pressed` and a visible focus ring

## Verification

- `npm run type-check` ✓ · `npm run lint` ✓ · `npm run format:check` ✓
- **285 unit tests** pass · **31 e2e tests** pass · production build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)