### PR TITLE
chore(deps): bump nanoid to 3.3.18 to fix high-severity advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5946,9 +5946,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What

Bumps the transitive `nanoid` dependency from **3.3.16 → 3.3.18** with a surgical lockfile edit (no `package.json` change — `nanoid` is not a direct dependency; it's pulled in via `postcss`).

## Why

The `security` CI job runs `npm audit --audit-level high --omit=dev` and was failing on a high-severity advisory:

> **nanoid `<3.3.17`** — GHSA-2v37-7h3g-55p8: custom generators can loop indefinitely when size is zero

This advisory is unrelated to any feature work, but because it's in the production dependency tree it turned the `security` job (and the `all-checks` gate) red on `main` and consequently on **every open Dependabot PR** (#255, #256, #257). Merging this unblocks all of them once their branches are rebased.

## How the fix was kept minimal

`npm audit fix` under the local npm version rewrote unrelated `libc`/`dev` lockfile fields (an ~85-line diff), so instead only the `nanoid` entry (version, resolved URL, integrity) was updated by hand — a clean 3-line change.

## Verification (local)

- `npm ci` accepts the edited lockfile
- `npm audit --audit-level high --omit=dev` → **found 0 vulnerabilities** (the exact security-job command)
- `npm run build` compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bz42ALgHqCNedy2a2zVXMP)_